### PR TITLE
Adding random component to pod's name

### DIFF
--- a/examples/sbseg2024.py
+++ b/examples/sbseg2024.py
@@ -142,8 +142,7 @@ class NetworkTopo( Topo ):
         self.addLink(s301, srv301)
         self.addLink(s301, fw301, ipv4_node2="192.168.30.254/24")
         self.addLink(s301, fw301, ipv4_node2="172.16.30.254/24")
-        self.addLink(s301, fw301, ipv4_node2="10.30.0.254/24")
-        self.addLink(s301, r301)
+        self.addLink(r301, fw301, ipv4_node2="10.30.0.254/24")
 
         ####################
         ## AS 400

--- a/mnsec/k8s.py
+++ b/mnsec/k8s.py
@@ -4,6 +4,7 @@ import time
 import os
 import sys
 import json
+from uuid import uuid4
 
 from mininet.log import info, error, warn, debug
 from mininet.node import Node
@@ -34,7 +35,7 @@ class K8sPod(Node):
         env: environment variables for the container. Example:
             env=[{"name": "XPTO", "value": "foobar"}]
         """
-        self.k8s_name = f"mnsec-{name}"
+        self.k8s_name = f"mnsec-{name}-{uuid4().hex[:14]}"
         self.k8s_image = image
         self.k8s_command = command
         self.k8s_pod_ip = None


### PR DESCRIPTION
Closes #8 

Workaround-for #9


### Description of the change

This pull request adds a new component to Pod's name: random string with 14 characters, to avoid conflict with other instances of mininet-sec running on the same Kubernetes cluster.


### Local tests

Before the PR:

```
root@mininet-sec-mayara1-7f4c6fbc75-z599q:/src/mnsec# python3 examples/sbseg2024.py 10.50.124.131
...
mininet-sec> py print(secflood1.k8s_name)
mnsec-secflood1
mininet-sec> py print(ids201.k8s_name)
mnsec-ids201
mininet-sec> sh kubectl get pods | grep mnsec
mnsec-ids201                           1/1     Running   0          2m9s
mnsec-secflood1                        1/1     Running   0          2m7s
```

After:

```
root@mininet-sec-mayara1-7f4c6fbc75-z599q:/src/mnsec# python3 examples/sbseg2024.py 10.50.124.131
....
mininet-sec> py print(secflood1.k8s_name)
mnsec-secflood1-cd491642f6044a
mininet-sec> py print(ids201.k8s_name)
mnsec-ids201-f801cc1a372541
mininet-sec> sh kubectl get pods | grep mnsec
mnsec-ids201-f801cc1a372541            1/1     Running   0          55s
mnsec-secflood1-cd491642f6044a         1/1     Running   0          54s
```

Also tested the cleanup procedure and it is working as expected.