### PR TITLE
Adding an option to avoid dynamic learning of the source IP address on the VXLAN tunnel

### DIFF
--- a/mnsec/link.py
+++ b/mnsec/link.py
@@ -76,12 +76,12 @@ class VxLanLink(Link):
 
         cmdOut1 = runCmd1(
             f"ip link add {intfname1} netns {netns1} {l2addr1} "
-            f"type vxlan id {vxlan_id} remote {node2_ip} dstport 8472",
+            f"type vxlan id {vxlan_id} remote {node2_ip} dstport 8472 nolearning",
             shell=True,
         )
         cmdOut2 = runCmd2(
             f"ip link add {intfname2} netns {netns2} {l2addr2} "
-            f"type vxlan id {vxlan_id} remote {node1_ip} dstport 8472",
+            f"type vxlan id {vxlan_id} remote {node1_ip} dstport 8472 nolearning",
             shell=True,
         )
 


### PR DESCRIPTION
Closes #18 

### Description of the change

This pull request adds the `nolearning` option on the VXLAN Link configuration to avoid Linux trying to learn the source IP address when establishing the tunnel dynamically. Instead of learning the IP address, with `nolearning` the source IP address will be used from what is configured.

Downside of such configuration is that it will be hard to configure VLXAN on groups (or point-to-multipoint), but since we are not using this, it will be okay.