### PR TITLE
Added feature to open host terminal on mouse double chick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED] - Under development
 
-- TODO
+- Added feature to open host terminal based on double check in the Mininet-Sec Web UI
 
 ## [1.1.0] - 2025-01-10
 

--- a/mnsec/api_server.py
+++ b/mnsec/api_server.py
@@ -147,6 +147,19 @@ class APIServer:
                     item["style"]["target-label"] = "" if show == "disabled" else "data(tlabel)"
             return self.default_stylesheet
 
+        clientside_callback(
+            """
+            function(input1) {
+              cy.on('dblclick', function(evt) {
+                window.open('/xterm/' + evt.target.id(), '_blank');
+              });
+              return dash_clientside.no_update;
+            }
+            """,
+            Output('cytoscape', 'id'),
+            Input('cytoscape', 'id')
+        )
+
         self.server.add_url_rule("/topology", None, self.get_topology, methods=["GET"])
         self.server.add_url_rule("/add_node", None, self.add_node, methods=["POST"])
         self.server.add_url_rule("/add_link", None, self.add_link, methods=["POST"])


### PR DESCRIPTION
Fix #26 

### Description of the change

- Check CHANGELOG for more details

### Local tests

In order to run the tests with this new feature (before releasing) I had to follow the steps described below:
1. Run a lab on HackInSDN Dashboard
2. run a `ps aux | grep tmux` (just to understand the running mnsec session)
3. Open Mininet-Sec console and connect to `tmux` running session
4. Stop the current running Mininet-Sec app (CTRL+D)
5. `git pull && git checkout fix/issue_26`
6. start the topology again (based on the output from step 2)