### PR TITLE
Dynamic load Analytics measurement scripts and js

### DIFF
--- a/mnsec/api_server.py
+++ b/mnsec/api_server.py
@@ -32,10 +32,12 @@ class APIServer:
         self.port = port
 
         # Analytics measurements
-        self.analytics_script = os.getenv("ANALYTICS_SCRIPT")
+        self.gtag = os.getenv("GTAG")
         external_scripts = []
-        if os.getenv("ANALYTICS_JSFILE"):
-            external_scripts.append(os.getenv("ANALYTICS_JSFILE"))
+        if self.gtag:
+            external_scripts.append(
+                f"https://www.googletagmanager.com/gtag/js?id={self.gtag}"
+            )
 
         self.server = flask.Flask(__name__)
         self.app = Dash(
@@ -171,13 +173,18 @@ class APIServer:
             Input('cytoscape', 'id')
         )
 
-        if self.analytics_script:
+        if self.gtag:
             clientside_callback(
                 """
                 function(input1) {
-                  {}
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag () {
+                    dataLayer.push(arguments);
+                  };
+                  gtag('js',new Date());
+                  gtag('config', '%s');
                 }
-                """.format(self.analytics_script),
+                """ % (self.gtag),
                 Output('cytoscape', 'id'),
                 Input('cytoscape', 'id')
             )

--- a/mnsec/k8s.py
+++ b/mnsec/k8s.py
@@ -88,6 +88,8 @@ class K8sPod(Node):
         self.k8s_args = args
         self.k8s_pod_ip = None
         self.k8s_env = env
+        if os.getenv("GTAG"):
+            self.k8s_env.append({"name": "GTAG", "value": os.getenv("GTAG")})
         self.k8s_publish = self.parse_publish(publish)
         self.port_forward = []
         self.waitRunning = waitRunning

--- a/mnsec/k8s.py
+++ b/mnsec/k8s.py
@@ -292,8 +292,8 @@ class K8sPod(Node):
             proto = kwargs.get("proto", "tcp")
             if not port2:
                 continue
-            self.cmd(f"socat -lpmnsec-socat-unix-local-{port2}-{proto} unix-listen:/tmp/local-{port2}-{proto}.sock,fork {proto}:127.0.0.1:{port2} &")
-            self.cmd(f"ip netns exec mgmt socat -lpmnsec-socat-local-{port2}-{proto}-unix {proto}-listen:{port2},bind=0.0.0.0,reuseaddr,fork unix-connect:/tmp/local-{port2}-{proto}.sock &")
+            self.cmd(f"socat -lpmnsec-socat-unix-local-{port2}-{proto} unix-listen:/tmp/local-{port2}-{proto}.sock,fork {proto}:127.0.0.1:{port2} >/dev/null 2>&1 &", shell=True)
+            self.cmd(f"ip netns exec mgmt socat -lpmnsec-socat-local-{port2}-{proto}-unix {proto}-listen:{port2},bind=0.0.0.0,reuseaddr,fork unix-connect:/tmp/local-{port2}-{proto}.sock >/dev/null 2>&1 &", shell=True)
 
     def delete_port_forward(self):
         """Delete port forward."""

--- a/mnsec/templates/xterm.html
+++ b/mnsec/templates/xterm.html
@@ -1,7 +1,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Mininet-Sec</title>
+    <title>mnsec xterm - {{host}}</title>
     <style>
       html {
         font-family: arial;
@@ -145,5 +145,11 @@
         socket.emit('disconnect', {'host': "{{host}}"});
       }
     </script>
+    {% if gtag %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{gtag}}"></script>
+    <script>
+      window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);};gtag('js',new Date());gtag('config', '{{gtag}}');
+    </script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Fix #42 

Fix #41 

### Description of the change

This PR adds the capability of dynamically loading javascript files and inline javascript code in order to enable Analytics Measurements. I decided to keep this measurement specific for Google Analytics (GTAG) for now, to avoid any risk of code injection on the application based on the environment var. So, in order to enable Google Analytics measurement you just need to define the env var `GTAG` with the tag you get from google tag manager.

Additionally, this PR also fixes an error when loading services and exporting ports on K8sPods.

Finally, a few improvements were applied to Mininet-Sec API Server and Xterm templates to facilitate the data visualization on GAnalytics.