### PR TITLE
Feat/setup dns hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [UNRELEASED] - Under development
 
 - Added feature to open host terminal based on double check in the Mininet-Sec Web UI
+- Added script to setup DNS service based on bind9 (`service-mnsec-bind9.sh`), with options: enable the DNS server, enable recursion, add a zone, add entires to a zone
+- Fixed issue with Kubernetes terminals that could freeze/stop-working after a while
+- Added feature to display images for hosts, switches, Pods, etc
+- Added option to allow user to provide an URL with image to be displayed (`img_url`)
+- Added option to allow Mininet-Sec hosts to configure DNS resolvers (`dns_nameservers`)
+- Added option to allow run post startup commands (`postStart`)
 
 ## [1.1.0] - 2025-01-10
 

--- a/bin/service-mnsec-bind9.sh
+++ b/bin/service-mnsec-bind9.sh
@@ -33,6 +33,10 @@ while [[ $# -gt 0 ]]; do
       ACTION=add-entry
       shift
       ;;
+    --enable-recursive)
+      ACTION=enable-recursive
+      shift
+      ;;
     -h|--help)
       ACTION=help
       shift
@@ -144,6 +148,17 @@ function add_entry(){
 	named-checkzone $ZONE $BASE_DIR/etc/bind/db.$ZONE
 }
 
+function enable_recursive(){
+	# check if bind9 is running
+	if ! rndc status | grep -q "server is up and running"; then
+		echo "bind9 is not runnig! Please run --start first"
+		exit 0
+	fi
+	echo "Enabling recursive queries"
+	sed -i "/recursion/d" $BASE_DIR/etc/bind/named.conf.options
+	sed -i "/listen-on-v6/a\        recursion yes;\n        allow-recursion { any; };" $BASE_DIR/etc/bind/named.conf.options
+}
+
 if [ "$ACTION" = "start" ]; then
   start
 elif [ "$ACTION" = "stop" ]; then
@@ -159,6 +174,9 @@ elif [ "$ACTION" = "add-reverse-zone" ]; then
 elif [ "$ACTION" = "add-entry" ]; then
   add_entry ${ORIG_ARGS[@]}
   reload
+elif [ "$ACTION" = "enable-recursive" ]; then
+  enable_recursive
+  reload
 else
   echo "USAGE: $0 NAME [OPTIONS]"
   echo ""
@@ -169,6 +187,7 @@ else
   echo "  --add-zone ...           Add direct zone (see more information below)"
   echo "  --add-reverse-zone ...   Add reverse zone (see more information below)"
   echo "  --add-entry ...          Add an entry to a zone (see more information below)"
+  echo "  --enable-recursive       Enable recursive query from any client"
   echo ""
   echo "--add-zone ZONE [FILE]"
   echo "  ZONE    FQDN (Full Qualified Domain Name) of the zone to be added. Example: xpto.com"

--- a/examples/multi-as.py
+++ b/examples/multi-as.py
@@ -190,15 +190,14 @@ class NetworkTopo( Topo ):
 
         srv501 = self.addHost('srv501', ip='172.16.50.1/24', defaultRoute='via 172.16.50.254', apps=[{"name": "http", "port": 80}, {"name": "https", "port": 443}], group="AS500")
         srv502 = self.addHost('srv502', ip='172.16.50.2/24', defaultRoute='via 172.16.50.254', group="AS500")
-        srv503 = self.addHost('srv503', ip='172.16.50.3/24', defaultRoute='via 172.16.50.254', group="AS500")
-        # setup dns services on this host
-        srv503.params["postStart"] = [
+        srv503_postStart = [
             "service-mnsec-bind9.sh srv503 --start",
             "service-mnsec-bind9.sh srv503 --enable-recursion",
             "service-mnsec-bind9.sh srv503 --add-zone hackinsdn.com",
             "service-mnsec-bind9.sh srv503 --add-entry hackinsdn.com \"iodine IN A 172.16.50.2\"",
             "service-mnsec-bind9.sh srv503 --add-entry hackinsdn.com \"testetun IN NS iodine\"",
         ]
+        srv503 = self.addHost('srv503', ip='172.16.50.3/24', defaultRoute='via 172.16.50.254', group="AS500", postStart=srv503_postStart)
 
         s501 = self.addSwitch('s501', cls=LinuxBridge, group="AS500")
 

--- a/examples/multi-as.py
+++ b/examples/multi-as.py
@@ -37,7 +37,7 @@ class NetworkTopo( Topo ):
         ####################
         r101 = self.addHost('r101', ip='10.10.0.1/24', mynetworks=[], group="AS100")
 
-        h101 = self.addHost('h101', ip='192.168.10.1/24', defaultRoute='via 192.168.10.254', group="AS100")
+        h101 = self.addHost('h101', ip='192.168.10.1/24', defaultRoute='via 192.168.10.254', group="AS100", dns_nameservers="172.16.50.3")
         h102 = self.addHost('h102', ip='192.168.10.2/24', defaultRoute='via 192.168.10.254', group="AS100")
         h103 = self.addHost('h103', ip='192.168.10.3/24', defaultRoute='via 192.168.10.254', group="AS100")
 
@@ -191,6 +191,14 @@ class NetworkTopo( Topo ):
         srv501 = self.addHost('srv501', ip='172.16.50.1/24', defaultRoute='via 172.16.50.254', apps=[{"name": "http", "port": 80}, {"name": "https", "port": 443}], group="AS500")
         srv502 = self.addHost('srv502', ip='172.16.50.2/24', defaultRoute='via 172.16.50.254', group="AS500")
         srv503 = self.addHost('srv503', ip='172.16.50.3/24', defaultRoute='via 172.16.50.254', group="AS500")
+        # setup dns services on this host
+        srv503.params["postStart"] = [
+            "service-mnsec-bind9.sh srv503 --start",
+            "service-mnsec-bind9.sh srv503 --enable-recursion",
+            "service-mnsec-bind9.sh srv503 --add-zone hackinsdn.com",
+            "service-mnsec-bind9.sh srv503 --add-entry hackinsdn.com \"iodine IN A 172.16.50.2\"",
+            "service-mnsec-bind9.sh srv503 --add-entry hackinsdn.com \"testetun IN NS iodine\"",
+        ]
 
         s501 = self.addSwitch('s501', cls=LinuxBridge, group="AS500")
 

--- a/mnsec/k8s.py
+++ b/mnsec/k8s.py
@@ -277,6 +277,9 @@ class K8sPod(Node):
             self.cmd(f"ip netns exec mgmt ip route add {route.strip()} dev eth0 scope link")
         for route in routes_global:
             self.cmd(f"ip netns exec mgmt ip route add {route.strip()} dev eth0 scope global")
+        # setup DNS for the mgmt namespace according to original Kubernetes config
+        self.cmd(f"mkdir -p /etc/netns/mgmt")
+        self.cmd(f"cat /etc/resolv.conf > /etc/netns/mgmt/resolv.conf")
 
     def setup_port_forward(self):
         """Create port forward for the pod."""

--- a/mnsec/net.py
+++ b/mnsec/net.py
@@ -262,10 +262,10 @@ class Mininet_sec(Mininet):
            dns_extra_opts (str): extra options to be added to resolv.conf
         """
         host = host if not isinstance( host, str ) else self[ host ]
-        extra_opts = self.params.get("dns_extra_opts", "")
+        extra_opts = host.params.get("dns_extra_opts", "")
         config = [
             f"nameserver {server}"
-            for server in self.params.get("dns_nameservers", "").split()
+            for server in host.params.get("dns_nameservers", "").split()
         ]
         if extra_opts:
             config.append(extra_opts)

--- a/mnsec/net.py
+++ b/mnsec/net.py
@@ -284,6 +284,8 @@ class Mininet_sec(Mininet):
         self.setupHostDNS(host)
         if hasattr(host, "start"):
             host.start()
+        for cmd in host.params.get("postStart", []):
+            host.cmd(cmd)
 
     def enable_sflow(self):
         """Enable sflow on switches."""


### PR DESCRIPTION
Fix #43 
Fix #44 
Fix #45 
Fix #40 

### Description of the change

This PR includes several fixes/improvements:

- Issue #40: handling disconnected kubernetes nodes and trying to re-setup the shell 
- Issue #43: change bind9 startup script to allow enabling recursion
- Issue #44: disable DNSSEC validation for local defined zones
- Issue #45: allow defining the DNS name resolvers and other extra options