### PR TITLE
fix the default value for settings when loading yaml

### DIFF
--- a/mnsec/net.py
+++ b/mnsec/net.py
@@ -203,7 +203,7 @@ class Mininet_sec(Mininet):
     def processTopoSettings(self):
         """When using the yaml topology, process settings attribute"""
         if not self.topo_dict.get("settings") or not isinstance(self.topo_dict["settings"], dict):
-            return
+            return {}
         mnsec_attrs = [
             "apps",
             "workDir",


### PR DESCRIPTION
Fix #51 

### Description of the change

Minor fix for lab topology files (yaml) which does not include the settings field.