### PR TITLE
Open node terminal based on event target instead of selected node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added option to run the Kubernetes Pods without isolating the control network (i.e., network provided by Kubernets, usually `eth0`) keeping the control net in the root netns (`isolateControlNet`)
 - Fixed issue with bind9 mnsec service for the regex to validade zone being added
 - Added support for sysctls definition on Kubernetes Pods
+- Enhanced open terminal on right click to leverage event target instead of selected node (#60)
 
 ## [1.1.0] - 2025-01-10
 

--- a/mnsec/assets/ctxMenuFns.js
+++ b/mnsec/assets/ctxMenuFns.js
@@ -162,11 +162,9 @@ window.dashCytoscapeFunctions = Object.assign(
 	    mnsecAddLink();
         },
         mnsec_open_xterm: function (event) {
-	    const selectedNodes = cy.nodes(":selected");
-            const selectedNodeIds = selectedNodes.map((node) =>
-                node.data("label")
-            );
-            selectedNodeIds.forEach((nodeid) => {window.open(`/xterm/${nodeid}`, "_blank");});
+            var node = event.target;
+            var nodeid = node.data("label");
+            window.open(`/xterm/${nodeid}`, "_blank");
         },
         mnsec_add_group: function (event) {
             mnsecAddGroup();


### PR DESCRIPTION
Fix #60

This PR enhances the open node terminal function on right click based on event target instead of selected node. This avoids confusion because some students select one node and then right click on other nodes to open terminal.