### PR TITLE
add xterm dark/light theme

### DIFF
--- a/mnsec/templates/xterm.html
+++ b/mnsec/templates/xterm.html
@@ -55,7 +55,7 @@
         <button id="uarr" type="button">&uarr;</button>
         <button id="darr" type="button">&darr;</button>
         <button id="rarr" type="button">&rarr;</button>
-        <button id="themeButton" type="button">Tema Claro</button>
+        <button id="themeButton" type="button">☀︎</button>
       </div>
     </div>
     <!-- xterm -->
@@ -245,13 +245,6 @@
 
       /* Configure dark/light theme */
       /* Functions to deal with cookie to persist between xterm windows */
-      function setCookie(name, value, days) {
-        const expirationDate = new Date();
-        expirationDate.setDate(expirationDate.getDate() + days);
-        const cookie = `${name}=${value};expires=${expirationDate.toUTCString()};path=/`;
-        document.cookie = cookie;
-      }
-      
       function getCookie(name) {
         const cookies = document.cookie.split(';');
         for (let cookie of cookies) {
@@ -284,7 +277,7 @@
         isDarkTheme = !isDarkTheme;
         term.options.theme = isDarkTheme ? darkTheme : lightTheme;
         document.cookie = `xterm_theme=${isDarkTheme ? 'dark' : 'light'}`;
-        themeButton.textContent = isDarkTheme ? 'Tema Claro' : 'Tema Escuro';
+        themeButton.textContent = isDarkTheme ? '☀' : '❨';
       });
     </script>
     {% if gtag %}

--- a/mnsec/templates/xterm.html
+++ b/mnsec/templates/xterm.html
@@ -55,6 +55,7 @@
         <button id="uarr" type="button">&uarr;</button>
         <button id="darr" type="button">&darr;</button>
         <button id="rarr" type="button">&rarr;</button>
+        <button id="themeButton" type="button">Tema Claro</button>
       </div>
     </div>
     <!-- xterm -->
@@ -241,6 +242,50 @@
       window.onbeforeunload = function () {
         socket.emit('disconnect', {'host': "{{host}}"});
       }
+
+      /* Configure dark/light theme */
+      /* Functions to deal with cookie to persist between xterm windows */
+      function setCookie(name, value, days) {
+        const expirationDate = new Date();
+        expirationDate.setDate(expirationDate.getDate() + days);
+        const cookie = `${name}=${value};expires=${expirationDate.toUTCString()};path=/`;
+        document.cookie = cookie;
+      }
+      
+      function getCookie(name) {
+        const cookies = document.cookie.split(';');
+        for (let cookie of cookies) {
+          const [cookieName, cookieValue] = cookie.split('=').map(c => c.trim());
+          if (cookieName === name) {
+            return cookieValue;
+          }
+        }
+        return null;
+      }
+      const themeButton = document.getElementById('themeButton');
+      let isDarkTheme = getCookie('xterm_theme') === 'light' ? false : true;
+
+      const darkTheme = {
+        background: '#000',
+        foreground: '#fff',
+        cursor: '#fff', 
+        selectionBackground: '#fff', 
+        selectionForeground: '#000'
+      };
+      const lightTheme = {
+        background: '#fff',
+        foreground: '#000',
+        cursor: '#000', 
+        selectionBackground: '#000', 
+        selectionForeground: '#fff'
+      };
+
+      themeButton.addEventListener('click', () => {
+        isDarkTheme = !isDarkTheme;
+        term.options.theme = isDarkTheme ? darkTheme : lightTheme;
+        document.cookie = `xterm_theme=${isDarkTheme ? 'dark' : 'light'}`;
+        themeButton.textContent = isDarkTheme ? 'Tema Claro' : 'Tema Escuro';
+      });
     </script>
     {% if gtag %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{gtag}}"></script>


### PR DESCRIPTION
Sometimes (like presenting or in a light room) dark backgrounds are hard to see. This add a button one can click to invert the theme, choosing a light one.

It also is:

- ciclical: one can click to back to dark theme.

- persistent: it creates a cookie the configuration to others xterm windows.

Examples:

- Dark theme (default):

<img width="571" height="263" alt="image" src="https://github.com/user-attachments/assets/89c96b3d-326b-47e0-b27e-4a0647ac7449" />

- Light theme:

<img width="567" height="270" alt="image" src="https://github.com/user-attachments/assets/be275f84-5505-4c4c-8b0c-fc1712fde94a" />

Hope it can be useful for others :)