### PR TITLE
allow privileged mode and specify the capabilities needed for k8spod hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Added preStart commands to be used to prepare image before it is executed
 - Added support for imagePullSecrets on Kubernetes Pods
 - Added support for RemoteController with DNS in addition to IP
+- Added support for specifying a K8sPod with `privileged` mode
+- Added support for specifying a K8sPod with `capabilities` to be added
 
 ## [1.1.0] - 2025-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added support for RemoteController with DNS in addition to IP
 - Added support for specifying a K8sPod with `privileged` mode
 - Added support for specifying a K8sPod with `capabilities` to be added
+- Added rsync into hackinsdn/krill and hackinsdn/routinator by default
 
 ## [1.1.0] - 2025-01-10
 

--- a/docker-images/krill/Dockerfile
+++ b/docker-images/krill/Dockerfile
@@ -4,7 +4,7 @@ RUN set -x \
  && export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-		iproute2 net-tools iputils-ping \
+		iproute2 net-tools iputils-ping rsync \
 		socat procps curl jq tini uuid-runtime coreutils \
                 python3-minimal libpython3-stdlib gnupg2 ca-certificates \
  && curl -fsSL https://packages.nlnetlabs.nl/aptkey.asc | gpg --dearmor -o /usr/share/keyrings/nlnetlabs-archive-keyring.gpg \

--- a/docker-images/routinator/Dockerfile
+++ b/docker-images/routinator/Dockerfile
@@ -4,7 +4,7 @@ RUN set -x \
  && export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-		iproute2 net-tools iputils-ping \
+		iproute2 net-tools iputils-ping rsync \
 		socat procps curl jq tini uuid-runtime \
                 python3-minimal libpython3-stdlib gnupg2 ca-certificates \
  && curl -fsSL https://packages.nlnetlabs.nl/aptkey.asc | gpg --dearmor -o /usr/share/keyrings/nlnetlabs-archive-keyring.gpg \

--- a/examples/privileged-pod.yaml
+++ b/examples/privileged-pod.yaml
@@ -1,0 +1,9 @@
+name: topology with just one node to run GDB
+hosts:
+  pwn:
+    kind: k8spod
+    image: hackinsdn/binex-pwn:main
+    # this Pod will require special privileges to run PTRACE/GDB
+    # it could also be done with:
+    # privileged: true
+    capabilities: ["NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE"]

--- a/examples/topo-linear-2.yaml
+++ b/examples/topo-linear-2.yaml
@@ -1,7 +1,8 @@
 name: lab-ospf-multiarea
 settings:
   env:
-    DEFENVVAR1: xpto
+    - name: DEFENVVAR1
+      value: xpto
   # hosts_kind: default
   # switches_kind: default
   # links_kind: default

--- a/examples/topo-linear-2.yaml
+++ b/examples/topo-linear-2.yaml
@@ -16,6 +16,19 @@ hosts:
   r1:
     kind: k8spod
     image: hackinsdn/debian:latest
+    # example of a useless pre-start commands to create
+    # multiline files and run a few commands before link
+    # setup
+    preStart:
+      - |
+        cat << 'EOF' > /tmp/foobar.txt
+        this is a file test 123
+
+        test aa bbb $HOSTNAME
+        EOF
+        date >> /tmp/xpto2
+      - hostname >> /tmp/xpto3-hostname
+      - date >> /tmp/xpto4-date
   r2:
     kind: k8spod
     image: hackinsdn/debian:latest

--- a/mnsec/k8s.py
+++ b/mnsec/k8s.py
@@ -220,6 +220,10 @@ class K8sPod(Node):
                 ]
             pod_manifest["spec"].setdefault("securityContext", {})
             pod_manifest["spec"]["securityContext"]["sysctls"] = self.k8s_sysctls
+        if self.params.get("privileged"):
+            pod_manifest["spec"]["containers"][0]["securityContext"]["privileged"] = True
+        if isinstance(self.params.get("capabilities"), list):
+            pod_manifest["spec"]["containers"][0]["securityContext"]["capabilities"]["add"] = self.params["capabilities"]
         if self.k8s_imagePullSecrets:
             pod_manifest["spec"]["imagePullSecrets"] = self.k8s_imagePullSecrets
         pod_manifest_str = json.dumps(pod_manifest)

--- a/mnsec/link.py
+++ b/mnsec/link.py
@@ -35,13 +35,15 @@ class Link(MN_Link):
 
     def __init__(self, node1, node2, **params):
         """Create the link and change its alias/altname."""
+        alias1 = params.get("params1", {}).get("alias", params.pop("alias1", None))
+        alias2 = params.get("params2", {}).get("alias", params.pop("alias2", None))
         super().__init__(node1, node2, **params)
-        if "alias1" in params:
-            self.config_alias(self.intf1, params["alias1"])
-            self.intf1.params["alias"] = params["alias1"]
-        if "alias2" in params:
-            self.config_alias(self.intf2, params["alias2"])
-            self.intf2.params["alias"] = params["alias2"]
+        if alias1:
+            self.config_alias(self.intf1, alias1)
+            self.intf1.params["alias"] = alias1
+        if alias2:
+            self.config_alias(self.intf2, alias2)
+            self.intf2.params["alias"] = alias2
 
     def intfName(self, node, n):
         """


### PR DESCRIPTION
Fix #76 

Fix #78

## Description of the change

See CHANGELOG

## Local tests

```
root@mininet-sec-a4a5e9b420ab4f-69496b4f79-zkq6w:/src/mnsec# cat > test-priv-cap.yaml <<EOF
name: topology with just one node to run GDB
hosts:
  pwn:
    kind: k8spod
    image: hackinsdn/binex-pwn:main
    # this Pod will require special privileges to run PTRACE/GDB
    # it could also be done with:
    # privileged: true
    capabilities: ["NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE"]
EOF

root@mininet-sec-a4a5e9b420ab4f-69496b4f79-zkq6w:/src/mnsec# mnsec --topofile bla.yaml
*** Starting API/Dash server
APIServer listening on port 0.0.0.0:8050
 * Serving Flask app 'mnsec.api_server'
 * Debug mode: on
*** Error setting resource limits. Mininet's performance may be affected.
*** Creating network
*** Adding controller
*** Adding hosts:
pwn
*** Running hosts post-startup:
 pwn
*** Adding switches:

*** Adding links:

*** Configuring hosts
pwn *** defaultIntf: warning: pwn has no interfaces

*** Starting controller
c0
*** Starting 0 switches

*** Starting CLI:
mininet-sec>
```

Then, in another terminal:

```
root@mininet-sec-a4a5e9b420ab4f-69496b4f79-zkq6w:/src/mnsec# kubectl get pods
NAME                       READY   STATUS    RESTARTS   AGE
mnsec-pwn-a4a5e9b420ab4f   2/2     Running   0          68s
root@mininet-sec-a4a5e9b420ab4f-69496b4f79-zkq6w:/src/mnsec# kubectl exec -it mnsec-pwn-a4a5e9b420ab4f -- bash
Defaulted container "mnsec-pwn-a4a5e9b420ab4f" out of: mnsec-pwn-a4a5e9b420ab4f, mnsec-sidecar
root@mnsec-pwn-a4a5e9b420ab4f:~# cat > bla.c
#include <stdio.h>

int main (int argc, char ** argv) {
    int idade;

    printf("Me informa sua idade: ");
    scanf("%d", &idade);
    printf("Você me informou: %d\n", idade);

    return 0;
}
root@mnsec-pwn-a4a5e9b420ab4f:~# gcc bla.c
root@mnsec-pwn-a4a5e9b420ab4f:~# gdb ./a.out
GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./a.out...
(No debugging symbols found in ./a.out)
(gdb) run
Starting program: /root/a.out
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Me informa sua idade: 1
Você me informou: 1
[Inferior 1 (process 48) exited normally]
(gdb) quit
```
